### PR TITLE
fix: make cluster-wide service lookup optional in NOTES.txt

### DIFF
--- a/charts/helm-chart/templates/NOTES.txt
+++ b/charts/helm-chart/templates/NOTES.txt
@@ -7,26 +7,28 @@ To learn more about the release, try:
   $ helm status {{ .Release.Name }}
   $ helm get all {{ .Release.Name }}
 
-{{- $ingressLabel := split ":" .Values.services.webServer.label -}}
-{{- $selectorLabelKey := trim ($ingressLabel._0) -}}
-{{- $selectorLabelValue := trim ($ingressLabel._1) -}}
+{{- if .Values.autoDisplayApplicationUrl | default false }}
+  {{- /* Automatically find and display the application URL - requires cluster-wide permissions */ -}}
+  {{- $ingressLabel := split ":" .Values.services.webServer.label -}}
+  {{- $selectorLabelKey := trim ($ingressLabel._0) -}}
+  {{- $selectorLabelValue := trim ($ingressLabel._1) -}}
 
-{{- range $index, $spec := (lookup "v1" "Service" "" "").items -}}
+  {{- range $index, $spec := (lookup "v1" "Service" "" "").items -}}
     {{- $selector := .spec.selector -}}
     {{- $selectorValue := get $selector $selectorLabelKey -}}
 
     {{ if eq $selectorValue $selectorLabelValue }}
-        {{ $lbIngress := .status.loadBalancer.ingress }}
-        {{- if $lbIngress -}}
-          {{- $hostName := get (first $lbIngress) "hostname" -}}
-          {{- $ip := get (first $lbIngress) "ip" -}}
-          {{ $url := or $hostName $ip }}
+      {{ $lbIngress := .status.loadBalancer.ingress }}
+      {{- if $lbIngress -}}
+        {{- $hostName := get (first $lbIngress) "hostname" -}}
+        {{- $ip := get (first $lbIngress) "ip" -}}
+        {{ $url := or $hostName $ip }}
   You can access the application by using https://{{ $url }}/
-        {{- else -}}
+      {{- else -}}
   You appear to be using a non-standard load balancer configuration.
   Please check your deployment for the correct endpoint address.
         {{- end -}}
     {{- end -}}
-{{ end }}
+  {{- end }}
 
-You may need to wait a few minutes for {{ .Chart.Name }} to install before accessing the URL.
+You may need to wait a few minutes for {{ .Chart.Name }} to install before accessing the application.

--- a/charts/helm-chart/values.yaml
+++ b/charts/helm-chart/values.yaml
@@ -28,6 +28,11 @@ connectionCheckContainerMemory: 2Gi
 scanContainerCpu: 1400m
 scanContainerMemory: 8Gi
 
+# -- Enable automatic display of application URL after installation.
+# When enabled, attempts to find the LoadBalancer URL by looking up all Services in the cluster.
+# Requires cluster-wide Service read permissions, so disable if you have limited RBAC.
+autoDisplayApplicationUrl: false
+
 services:
   webServer:
     installationEnvironment: KUBERNETES

--- a/charts/helm-chart/values.yaml
+++ b/charts/helm-chart/values.yaml
@@ -29,8 +29,8 @@ scanContainerCpu: 1400m
 scanContainerMemory: 8Gi
 
 # -- Enable automatic display of application URL after installation.
-# When enabled, attempts to find the LoadBalancer URL by looking up all Services in the cluster.
-# Requires cluster-wide Service read permissions, so disable if you have limited RBAC.
+# When enabled, attempts to find the LoadBalancer URL by looking up all services in the cluster.
+# Requires cluster-wide service read permissions, so disable if you have limited RBAC.
 autoDisplayApplicationUrl: false
 
 services:


### PR DESCRIPTION
NOTES.txt is a template file that displays deployment information after a Helm chart has been installed. One of the purposes of this file is to try to automatically find and display the application URL. However, this requires cluster-wide service read permissions. Many teams only have rights to a dedicated namespace, and this lookup can break deployment.

The goal of this PR is to make the deployment URL lookup optional in the values.yaml. The automatic display of application URL after installation is disabled by default.