### PR TITLE
fix: make cluster-wide service lookup optional in NOTES.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # enterprise-helm-charts
 
-Helm charts for BSEE Kubernetes installation. 
+Helm charts for BSEE Kubernetes installation.
 Currently only contains the standard kubernetes BSEE installation helm chart.
 
-# Usage
+## Usage
 
 The command ```helm repo add bsee https://portswigger.github.io/enterprise-helm-charts/``` can be used to add the repo.
 
@@ -23,4 +23,3 @@ helm install ${RELEASE_NAME} bsee/burp-suite-enterprise-edition \
 Where ```enterpriseServerConnectionUsername``` and ```scanningResourceConnectionUsername``` are optional.
 
 More information about custom values can be found in [getting started](https://portswigger.net/burp/documentation/enterprise/getting-started/kubernetes/new-deployment/install-app#providing-custom-values-for-the-helm-chart) documentation.
-

--- a/charts/helm-chart/Chart.yaml
+++ b/charts/helm-chart/Chart.yaml
@@ -16,4 +16,4 @@ name: burp-suite-enterprise-edition
 sources:
 - https://github.com/portswigger/enterprise-helm-charts/
 type: application
-version: 2025.3.0
+version: 2025.3.1


### PR DESCRIPTION
NOTES.txt is a template file that displays deployment information after a Helm chart has been installed. One of the purposes of this file is to try to automatically find and display the application URL. However, this requires cluster-wide service read permissions. Many teams only have rights to a dedicated namespace, and this lookup can break deployment.

The goal of this PR is to make the deployment URL lookup optional in the values.yaml. The automatic display of application URL after installation is disabled by default.