### PR TITLE
fix: make cluster-wide service lookup optional in NOTES.txt

### DIFF
--- a/charts/helm-chart/templates/NOTES.txt
+++ b/charts/helm-chart/templates/NOTES.txt
@@ -30,5 +30,6 @@ To learn more about the release, try:
         {{- end -}}
     {{- end -}}
   {{- end }}
+{{ end }}
 
 You may need to wait a few minutes for {{ .Chart.Name }} to install before accessing the application.


### PR DESCRIPTION
NOTES.txt is a template file that displays deployment information after a Helm chart has been installed. One of the purposes of this file is to try to automatically find and display the application URL. However, this requires cluster-wide service read permissions. Many teams only have rights to a dedicated namespace, and this lookup can break deployment.

The goal of this PR is to make the deployment URL lookup optional in the [values.yaml](https://github.com/PortSwigger/enterprise-helm-charts/blob/main/charts/helm-chart/values.yaml). The automatic display of application URL after installation is disabled by default.

Minor modifications were also made:

- Update of chart-releaser-action to v1.7.0
- Configure the [kics-and-release.yaml](https://github.com/PortSwigger/enterprise-helm-charts/blob/main/.github/workflows/kics-and-release.yaml) workflow to run if the file is modified
- Update of the chart version to 2025.3.1
- Spaces and newlines changes to the main README.md to follow best practices
- Update of the chart documentation with the latest release of helm-docs